### PR TITLE
Corrected town/city field name

### DIFF
--- a/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
+++ b/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
@@ -123,7 +123,7 @@ class EssentialPurchaseRequest extends AbstractRequest
             $data['COM']             = $card->getCompany();
             $data['EMAIL']           = $card->getEmail();
             $data['OWNERZIP']        = $card->getPostcode();
-            $data['OWNERCITY']       = $card->getCity();
+            $data['OWNERTOWN']       = $card->getCity();
             $data['OWNERTELNO']      = $card->getPhone();
             $data['OWNERADDRESS']    = $card->getAddress1();
         }


### PR DESCRIPTION
Unbelievably, 'OWNERCITY' isn't actually a valid field, which was causing orders to be rejected by ePDQ. They have 'OWNERCTY' which I believe is actually for the 'county' component of the address. As we're passing the city value, I've corrected this field to be 'OWNERTOWN'.
