### PR TITLE
UTF8 support

### DIFF
--- a/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
+++ b/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
@@ -12,8 +12,8 @@ use Omnipay\Common\Message\AbstractRequest;
 class EssentialPurchaseRequest extends AbstractRequest
 {
 
-    protected $liveEndpoint = 'https://payments.epdq.co.uk/ncol/prod/orderstandard.asp';
-    protected $testEndpoint = 'https://mdepayments.epdq.co.uk/ncol/test/orderstandard.asp';
+    protected $liveEndpoint = 'https://payments.epdq.co.uk/ncol/prod/orderstandard_utf8.asp';
+    protected $testEndpoint = 'https://mdepayments.epdq.co.uk/ncol/test/orderstandard_utf8.asp';
 
     public function getClientId()
     {


### PR DESCRIPTION
On the assumption that the vast majority of sites (especially using Omnipay) will be using UTF8, I've changed the gateway endpoints to the ones supplied by Barclays that support this character set.
