### PR TITLE
Allow transactionId to be added to the post-payment feedback URL

### DIFF
--- a/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
+++ b/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
@@ -98,6 +98,9 @@ class EssentialPurchaseRequest extends AbstractRequest
         $data['PSPID']          = $this->getClientId();
 
         $data['ORDERID']        = $this->getTransactionId();
+        // Useful optional parameter which can be used as a variable in the post-payment feedback URL
+        // eg. The URL can be set in the ePDQ control panel as something like "https://www.example.com/callback/<PARAMVAR>"
+        $data['PARAMVAR']       = $this->getTransactionId();
         $data['CURRENCY']       = $this->getCurrency();
         $data['LANGUAGE']       = $this->getLanguage();
         $data['AMOUNT']         = $this->getAmountInteger();

--- a/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
+++ b/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
@@ -2,8 +2,6 @@
 
 namespace Omnipay\BarclaysEpdq\Message;
 
-use Omnipay\Common\Currency;
-use Omnipay\Common\Exception\InvalidRequestException;
 use Omnipay\Common\Message\AbstractRequest;
 
 /**
@@ -124,6 +122,9 @@ class EssentialPurchaseRequest extends AbstractRequest
         $items = $this->getItems();
         if ($items) {
             foreach ($items as $n => $item) {
+                /**
+                 * @var \Omnipay\Common\Item $item
+                 */
                 $data["ITEMNAME$n"] = $item->getName();
                 $data["ITEMDESC$n"] = $item->getDescription();
                 $data["ITEMQUANT$n"] = $item->getQuantity();


### PR DESCRIPTION
This change adds the optional PARAMVAR parameter to the payment request, setting it to the `transactionId`.

This means that users can set the feedback URL in the Barclays control panel to be something like:
    https://example.com/payment-callback/<PARAMVAR>