### PR TITLE
Truncate values inline with Barclays EPDQ documentation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         },
         {
             "name": "Omnipay Contributors",
-            "homepage": "https://github.com/barclays-epdq/contributors"
+            "homepage": "https://github.com/samvaughton/omnipay-barclays-epdq/graphs/contributors"
         }
     ],
     "autoload": {

--- a/src/Omnipay/BarclaysEpdq/Item.php
+++ b/src/Omnipay/BarclaysEpdq/Item.php
@@ -234,5 +234,4 @@ class Item extends \Omnipay\Common\Item
     {
         return parent::setName(substr($value, 0, 40));
     }
-
 }

--- a/src/Omnipay/BarclaysEpdq/Item.php
+++ b/src/Omnipay/BarclaysEpdq/Item.php
@@ -24,7 +24,7 @@ class Item extends \Omnipay\Common\Item
      */
     public function setId($value)
     {
-        return $this->setParameter('id', $value);
+        return $this->setParameter('id', substr($value, 0, 15));
     }
 
     /**
@@ -43,7 +43,7 @@ class Item extends \Omnipay\Common\Item
      */
     public function setCategory($value)
     {
-        return $this->setParameter('category', $value);
+        return $this->setParameter('category', substr($value, 0, 50));
     }
 
     /**
@@ -81,7 +81,7 @@ class Item extends \Omnipay\Common\Item
      */
     public function setComments($value)
     {
-        return $this->setParameter('comments', $value);
+        return $this->setParameter('comments', substr($value, 0, 255));
     }
 
     /**
@@ -216,4 +216,23 @@ class Item extends \Omnipay\Common\Item
     {
         return $this->setParameter('maximumQuantity', $value);
     }
+
+    /**
+     * @param string $value Max length of 16.
+     * @return $this
+     */
+    public function setDescription($value)
+    {
+        return parent::setDescription(substr($value, 0, 16));
+    }
+
+    /**
+     * @param string $value Max length of 40.
+     * @return $this
+     */
+    public function setName($value)
+    {
+        return parent::setName(substr($value, 0, 40));
+    }
+
 }

--- a/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
+++ b/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
@@ -22,7 +22,8 @@ class EssentialPurchaseRequest extends AbstractRequest
     }
 
     /**
-     * Your affiliation name in our system, chosen by yourself when opening your account with us. This is a unique identifier and can’t ever be changed.
+     * Your affiliation name in our system, chosen by yourself when opening your account with us.
+     * This is a unique identifier and can’t ever be changed.
      *
      * @param string $value Max length of 30.
      * @return AbstractRequest

--- a/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
+++ b/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
@@ -5,10 +5,7 @@ namespace Omnipay\BarclaysEpdq\Message;
 use Omnipay\BarclaysEpdq\PageLayout;
 use Omnipay\BarclaysEpdq\Delivery;
 use Omnipay\BarclaysEpdq\Feedback;
-use Omnipay\Common\Currency;
-use Omnipay\Common\Exception\InvalidRequestException;
 use Omnipay\Common\Message\AbstractRequest;
-use Omnipay\Omnipay;
 
 /**
  * BarclaysEpdq Essential Purchase Request
@@ -24,9 +21,15 @@ class EssentialPurchaseRequest extends AbstractRequest
         return $this->getParameter('clientId');
     }
 
+    /**
+     * Your affiliation name in our system, chosen by yourself when opening your account with us. This is a unique identifier and can’t ever be changed.
+     *
+     * @param string $value Max length of 30.
+     * @return AbstractRequest
+     */
     public function setClientId($value)
     {
-        return $this->setParameter('clientId', $value);
+        return $this->setParameter('clientId', substr($value, 0, 30));
     }
 
     public function getLanguage()
@@ -51,7 +54,7 @@ class EssentialPurchaseRequest extends AbstractRequest
 
     public function setDeclineUrl($value)
     {
-        return $this->setParameter('declineUrl', $value);
+        return $this->setParameter('declineUrl', substr($value, 0, 200));
     }
 
     public function getExceptionUrl()
@@ -61,18 +64,19 @@ class EssentialPurchaseRequest extends AbstractRequest
 
     public function setExceptionUrl($value)
     {
-        return $this->setParameter('exceptionUrl', $value);
+        return $this->setParameter('exceptionUrl', substr($value, 0, 200));
     }
 
     /**
      * This method keeps the backward compatibility with setDeclineUrl and setExceptionUrl.
      * It fills returnUrl, declineUrl and exceptionUrl with the same value.
      *
-     * @param string $value
+     * @param string $value Max length of 200
      * @return $this
      */
     public function setReturnUrl($value)
     {
+        $value = substr($value, 0, 200);
         $this->setParameter('returnUrl', $value);
         $this->setParameter('declineUrl', $value);
         $this->setParameter('exceptionUrl', $value);
@@ -196,7 +200,7 @@ class EssentialPurchaseRequest extends AbstractRequest
         if ($items) {
             foreach ($items as $n => $item) {
                 /**
-                 * @var \Omnipay\Common\Item $item
+                 * @var \Omnipay\BarclaysEpdq\Item $item
                  */
                 // item index always start from 1 not from 0
                 $index = $n + 1;


### PR DESCRIPTION
Some values within the Barclays EPDQ purchase request have certain limits.

Apply these limits using truncation.