### PR TITLE
Enforce string lengths for EPDQ items

### DIFF
--- a/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
+++ b/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
@@ -2,9 +2,11 @@
 
 namespace Omnipay\BarclaysEpdq\Message;
 
+use Omnipay\BarclaysEpdq\Item;
 use Omnipay\BarclaysEpdq\PageLayout;
 use Omnipay\BarclaysEpdq\Delivery;
 use Omnipay\BarclaysEpdq\Feedback;
+use Omnipay\Common\ItemBag;
 use Omnipay\Common\Message\AbstractRequest;
 
 /**
@@ -319,5 +321,23 @@ class EssentialPurchaseRequest extends AbstractRequest
     public function getEndpoint()
     {
         return $this->getTestMode() ? $this->testEndpoint : $this->liveEndpoint;
+    }
+
+    /**
+     * Set items for request
+     *
+     * Cast the items to instances of \Omnipay\BarclaysEpdq\Item
+     *
+     * @param array|\Omnipay\Common\ItemBag|\Omnipay\Common\Item[] $items
+     * @return AbstractRequest
+     */
+    public function setItems($items)
+    {
+        $newItems = new ItemBag();
+        foreach($items as $item){
+            $newItems->add(new Item($item->getParameters()));
+        }
+
+        return parent::setItems($newItems);
     }
 }

--- a/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
+++ b/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
@@ -334,7 +334,7 @@ class EssentialPurchaseRequest extends AbstractRequest
     public function setItems($items)
     {
         $newItems = new ItemBag();
-        foreach($items as $item){
+        foreach ($items as $item) {
             $newItems->add(new Item($item->getParameters()));
         }
 


### PR DESCRIPTION
Cast the ItemBag to a bag of \Omnipay\BarclaysEpdq\Item items, rather than leaving them as \Omnipay\Common\Items. This enforces the item lengths as required by the gateway.