### PR TITLE
Fix orders with a mix of blank/non-blank descriptions.

### DIFF
--- a/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
+++ b/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
@@ -209,7 +209,8 @@ class EssentialPurchaseRequest extends AbstractRequest
                     // item index always start from 1 not from 0
                     ++$index;
                     $data["ITEMNAME$index"]            = $item->getName();
-                    $data["ITEMDESC$index"]            = $item->getDescription() ?: ' '; // Empty descriptions are not allowed.
+                    // Empty descriptions are not allowed.
+                    $data["ITEMDESC$index"]            = $item->getDescription() ?: ' ';
                     $data["ITEMQUANT$index"]           = $item->getQuantity();
                     $data["ITEMPRICE$index"]           = $this->formatCurrency($item->getPrice());
                     if (is_a($item, 'Omnipay\BarclaysEpdq\Item')) {

--- a/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
+++ b/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
@@ -199,19 +199,17 @@ class EssentialPurchaseRequest extends AbstractRequest
             $data['OWNERADDRESS2']   = $card->getAddress2();
         }
 
+        /** @var \Omnipay\BarclaysEpdq\Item[] $items */
         $items = $this->getItems();
         if ($items) {
             $index = 0;
             foreach ($items as $n => $item) {
                 // Ignore zero priced items as too many causes problems with Barclays EPDQ.
                 if ($item->getPrice() <> 0) {
-                    /**
-                     * @var \Omnipay\BarclaysEpdq\Item $item
-                     */
                     // item index always start from 1 not from 0
                     ++$index;
                     $data["ITEMNAME$index"]            = $item->getName();
-                    $data["ITEMDESC$index"]            = $item->getDescription();
+                    $data["ITEMDESC$index"]            = $item->getDescription() ?: ' '; // Empty descriptions are not allowed.
                     $data["ITEMQUANT$index"]           = $item->getQuantity();
                     $data["ITEMPRICE$index"]           = $this->formatCurrency($item->getPrice());
                     if (is_a($item, 'Omnipay\BarclaysEpdq\Item')) {


### PR DESCRIPTION
If an order has item without a description before an item with a description, the order would fail.

Blank entries are removed from the set of data transmitted to Barclays.

To allow a blank description through, this commit uses a single space as the description.