### PR TITLE
Update Omnipay to league/omnipay v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "coxeh/omnipay-barclays-epdq",
+    "name": "digitickets/omnipay-barclays-epdq",
     "type": "library",
     "description": "Barclays ePDQ driver for the Omnipay payment processing library.",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,8 @@
         "psr-0": { "Omnipay\\BarclaysEpdq\\" : "src/" }
     },
     "require": {
-        "omnipay/common": "~2.0"
+        "league/omnipay": "^3.2.1"
     },
     "require-dev": {
-        "omnipay/tests": "~2.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "digitickets/omnipay-barclays-epdq",
+    "name": "coxeh/omnipay-barclays-epdq",
     "type": "library",
     "description": "Barclays ePDQ driver for the Omnipay payment processing library.",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,12 @@
     "require": {
         "league/omnipay": "^3.2.1"
     },
+    "scripts": {
+        "docker-update": "docker run --rm --interactive --tty --volume $PWD:/app composer update",
+        "docker-test": "docker run --rm --interactive --tty --volume $PWD:/app composer run test",
+        "test": "./vendor/bin/phpunit -c ./phpunit.xml.dist"
+    },
     "require-dev": {
+        "omnipay/tests": "~4.1.1"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,8 +7,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Omnipay Test Suite">
             <directory>./tests/</directory>

--- a/src/Omnipay/BarclaysEpdq/EssentialGateway.php
+++ b/src/Omnipay/BarclaysEpdq/EssentialGateway.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\BarclaysEpdq;
 
+use Omnipay\BarclaysEpdq\Message\EssentialCompletePurchaseRequest;
 use Omnipay\Common\AbstractGateway;
 
 /**
@@ -29,7 +30,7 @@ class EssentialGateway extends AbstractGateway
 
     /**
      * @param array $parameters
-     * @return \Omnipay\BarclaysEpdq\Message\EssentialPurchaseRequest
+     * @return \Omnipay\Common\Message\AbstractRequest
      */
     public function purchase(array $parameters = array())
     {
@@ -41,7 +42,7 @@ class EssentialGateway extends AbstractGateway
 
     /**
      * @param array $parameters
-     * @return \Omnipay\BarclaysEpdq\Message\EssentialCompletePurchaseRequest
+     * @return \Omnipay\Common\Message\AbstractRequest
      */
     public function completePurchase(array $parameters = array())
     {

--- a/src/Omnipay/BarclaysEpdq/EssentialGateway.php
+++ b/src/Omnipay/BarclaysEpdq/EssentialGateway.php
@@ -2,6 +2,8 @@
 
 namespace Omnipay\BarclaysEpdq;
 
+use Omnipay\BarclaysEpdq\Message\EssentialCompletePurchaseRequest;
+use Omnipay\BarclaysEpdq\Message\EssentialPurchaseRequest;
 use Omnipay\Common\AbstractGateway;
 
 /**
@@ -29,7 +31,7 @@ class EssentialGateway extends AbstractGateway
 
     /**
      * @param array $parameters
-     * @return \Omnipay\Common\Message\AbstractRequest
+     * @return EssentialPurchaseRequest
      */
     public function purchase(array $parameters = array())
     {
@@ -41,7 +43,7 @@ class EssentialGateway extends AbstractGateway
 
     /**
      * @param array $parameters
-     * @return \Omnipay\Common\Message\AbstractRequest
+     * @return EssentialCompletePurchaseRequest
      */
     public function completePurchase(array $parameters = array())
     {

--- a/src/Omnipay/BarclaysEpdq/EssentialGateway.php
+++ b/src/Omnipay/BarclaysEpdq/EssentialGateway.php
@@ -2,7 +2,6 @@
 
 namespace Omnipay\BarclaysEpdq;
 
-use Omnipay\BarclaysEpdq\Message\EssentialCompletePurchaseRequest;
 use Omnipay\Common\AbstractGateway;
 
 /**

--- a/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
+++ b/src/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequest.php
@@ -218,10 +218,10 @@ class EssentialPurchaseRequest extends AbstractRequest
                         $data["ITEMCOMMENTS$index"]        = $item->getComments();
                         $data["ITEMCATEGORY$index"]        = $item->getCategory();
                         $data["ITEMATTRIBUTES$index"]      = $item->getAttributes();
-                        $data["ITEMDISCOUNT$index"]        = $this->formatCurrency($item->getDiscount());
+                        $data["ITEMDISCOUNT$index"]        = $this->formatCurrency($item->getDiscount() ?? 0);
                         $data["ITEMUNITOFMEASURE$index"]   = $item->getUnitOfMeasure();
                         $data["ITEMWEIGHT$index"]          = $item->getWeight();
-                        $data["ITEMVAT$index"]             = $this->formatCurrency($item->getVat());
+                        $data["ITEMVAT$index"]             = $this->formatCurrency($item->getVat() ?? 0);
                         $data["ITEMVATCODE$index"]         = $item->getVatCode();
                         $data["ITEMFDMPRODUCTCATEG$index"] = $item->getFraudModuleCategory();
                         $data["ITEMQUANTORIG$index"]       = $item->getMaximumQuantity();

--- a/tests/Omnipay/BarclaysEpdq/EssentialGatewayTest.php
+++ b/tests/Omnipay/BarclaysEpdq/EssentialGatewayTest.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\BarclaysEpdq;
 
+use Omnipay\Common\Exception\InvalidResponseException;
 use Omnipay\Tests\GatewayTestCase;
 
 class EssentialGatewayTest extends GatewayTestCase
@@ -12,10 +13,9 @@ class EssentialGatewayTest extends GatewayTestCase
      */
     protected $gateway;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
-
         $this->gateway = new EssentialGateway($this->getHttpClient(), $this->getHttpRequest());
 
         $this->options = array(
@@ -57,7 +57,7 @@ class EssentialGatewayTest extends GatewayTestCase
         $this->assertFalse($response->isSuccessful());
         $this->assertTrue($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
-        $this->assertContains('https://payments.epdq.co.uk/ncol/prod/order', $response->getRedirectUrl());
+        $this->assertStringContainsString('https://payments.epdq.co.uk/ncol/prod/order', $response->getRedirectUrl());
     }
 
     public function testCompletePurchaseSuccess()
@@ -90,9 +90,6 @@ class EssentialGatewayTest extends GatewayTestCase
         $this->assertSame("Authorised", $response->getMessage());
     }
 
-    /**
-     * @expectedException \Omnipay\Common\Exception\InvalidResponseException
-     */
     public function testCompletePurchaseInvalidShaComputation()
     {
         $this->getHttpRequest()->request->replace(
@@ -100,6 +97,8 @@ class EssentialGatewayTest extends GatewayTestCase
                 'SHASIGN' => 'fake',
             )
         );
+
+        $this->expectException(InvalidResponseException::class);
 
         $this->gateway->completePurchase($this->options)->send();
     }

--- a/tests/Omnipay/BarclaysEpdq/Message/EssentialCompletePurchaseRequestTest.php
+++ b/tests/Omnipay/BarclaysEpdq/Message/EssentialCompletePurchaseRequestTest.php
@@ -7,7 +7,7 @@ use Omnipay\Tests\TestCase;
 class EssentialCompletePurchaseRequestTest extends TestCase
 {
 
-    public function setUp()
+    protected function setUp() :void
     {
         parent::setUp();
 

--- a/tests/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequestTest.php
+++ b/tests/Omnipay/BarclaysEpdq/Message/EssentialPurchaseRequestTest.php
@@ -19,7 +19,7 @@ class EssentialPurchaseRequestTest extends TestCase
      */
     protected $request;
 
-    public function setUp()
+    protected function setUp() :void
     {
         parent::setUp();
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,4 @@
 <?php
-
 error_reporting(E_ALL | E_STRICT);
 
 // include the composer autoloader


### PR DESCRIPTION
This update allows for the league/omnipay version 3 to fix the abandoned omnipay/omnipay package. 
Unit tests are passing and a manual test using a test EPDQ gateway returned a success.